### PR TITLE
Multiple CMAKE_MODULE_PATH entries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ if(USE_LIBCXX)
     set(ADDITIONAL_LIBS "pthread")
 endif()
 
-set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/config")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/config")
 
 find_package(Boost 1.54 COMPONENTS system log date_time thread chrono regex random REQUIRED)
 find_package(ZeroMQ 4.0 REQUIRED)


### PR DESCRIPTION
Allows azmq to be part of a more complex build structure, particularly when combined with automatically-downloaded dependencies, as shown in https://crascit.com/2015/07/25/cmake-gtest/.

I have an example that shows the automated cmake-based downloads at https://github.com/eigengo/reactive-architectures-cookbook-code/tree/master/dm-to-rms/recognition